### PR TITLE
Update dependencies

### DIFF
--- a/features/step_definitions/stepDefinitions.js
+++ b/features/step_definitions/stepDefinitions.js
@@ -1,5 +1,4 @@
 // features/step_definitions/stepDefinitions.js
-
 var angularPage = require('../pages/homePage.js');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
@@ -9,26 +8,29 @@ var expect = chai.expect;
 
 
 module.exports = function() {
-  this.Given(/^I go to "([^"]*)"$/, function(site) {
+  this.Given(/^I go to "([^"]*)"$/, function(site, next) {
     //browser.get(site);
     angularPage.go(site);
+    expect(browser.getTitle()).to.eventually.equal('AngularJS — Superheroic JavaScript MVW Framework').and.notify(next);
   });
 
-  this.When(/^I add "([^"]*)" in the task field$/, function(task) {
+  this.When(/^I add "([^"]*)" in the task field$/, function(task, next) {
     //element(by.model('todoList.todoText')).sendKeys(task);
     angularPage.addTask(task);
+    next();
   });
 
-  this.When(/^I click the add button$/, function() {
+  this.When(/^I click the add button$/, function(next) {
     //var el = element(by.css('[value="add"]'));
     //el.click();
     angularPage.submitTask();
+    next();
   });
 
-  this.Then(/^I should see my new task in the list$/, function(callback) {
+  this.Then(/^I should see my new task in the list$/, function(next) {
     var todoList = angularPage.angularHomepage.todoList;
     expect(todoList.count()).to.eventually.equal(3);
     expect(todoList.get(2).getText()).to.eventually.equal('Be Awesome')
-      .and.notify(callback);
+      .and.notify(next);
   });
 };

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
+    "chai-as-promised": "^6.0.0",
     "chai-string": "^1.2.0",
-    "cucumber": "^1.0.0",
+    "cucumber": "^1.3.2",
     "gulp": "^3.9.1",
-    "gulp-angular-protractor": "^0.1.1",
-    "protractor": "^3.3.0",
-    "protractor-cucumber-framework": "^0.6.0"
+    "gulp-angular-protractor": "^0.4.2",
+    "protractor": "^5.1.1",
+    "protractor-cucumber-framework": "^3.1.0"
   },
   "scripts": {
     "test": "protractor"


### PR DESCRIPTION
Update all dependencies that were out of date.

left cucumber at 1.3.2 as there is a pretty substantial change to the structure of tests with v. 2. Will work on getting that updated next.

Also added an assertion for browser title to the first step.
Should fix issue #2 